### PR TITLE
Fix: 修复 get_message_of_id 并重命名撤回消息 API 名称

### DIFF
--- a/nonebot/adapters/qqguild/api/client.py
+++ b/nonebot/adapters/qqguild/api/client.py
@@ -8,7 +8,7 @@ from .model import *
 if TYPE_CHECKING:
 
     class ApiClient:
-        async def get_guild(self, guild_id: int) -> Guild:
+        async def get_guild(self, *, guild_id: int) -> Guild:
             ...
 
         async def me(self) -> User:
@@ -16,13 +16,14 @@ if TYPE_CHECKING:
 
         async def guilds(
             self,
+            *,
             before: Optional[str] = ...,
             after: Optional[str] = ...,
             limit: Optional[float] = ...,
         ) -> List[Guild]:
             ...
 
-        async def get_channels(self, guild_id: int) -> List[Channel]:
+        async def get_channels(self, *, guild_id: int) -> List[Channel]:
             ...
 
         async def post_channels(
@@ -39,7 +40,7 @@ if TYPE_CHECKING:
         ) -> List[Channel]:
             ...
 
-        async def get_channel(self, channel_id: int) -> Channel:
+        async def get_channel(self, *, channel_id: int) -> Channel:
             ...
 
         async def patch_channel(
@@ -55,18 +56,19 @@ if TYPE_CHECKING:
         ) -> Channel:
             ...
 
-        async def delete_channel(self, channel_id: int) -> None:
+        async def delete_channel(self, *, channel_id: int) -> None:
             ...
 
         async def get_members(
             self,
+            *,
             guild_id: int,
             after: Optional[str] = ...,
             limit: Optional[float] = ...,
         ) -> List[Member]:
             ...
 
-        async def get_member(self, guild_id: int, user_id: int) -> Member:
+        async def get_member(self, *, guild_id: int, user_id: int) -> Member:
             ...
 
         async def delete_member(
@@ -74,7 +76,7 @@ if TYPE_CHECKING:
         ) -> None:
             ...
 
-        async def get_guild_roles(self, guild_id: int) -> GetGuildRolesReturn:
+        async def get_guild_roles(self, *, guild_id: int) -> GetGuildRolesReturn:
             ...
 
         async def post_guild_role(
@@ -98,7 +100,7 @@ if TYPE_CHECKING:
         ) -> PatchGuildRoleReturn:
             ...
 
-        async def delete_guild_role(self, guild_id: int, role_id: int) -> None:
+        async def delete_guild_role(self, *, guild_id: int, role_id: int) -> None:
             ...
 
         async def put_guild_member_role(
@@ -112,7 +114,7 @@ if TYPE_CHECKING:
             ...
 
         async def get_channel_permissions(
-            self, channel_id: int, user_id: int
+            self, *, channel_id: int, user_id: int
         ) -> ChannelPermissions:
             ...
 
@@ -127,7 +129,7 @@ if TYPE_CHECKING:
             ...
 
         async def get_channel_roles_permissions(
-            self, channel_id: int, role_id: int
+            self, *, channel_id: int, role_id: int
         ) -> ChannelPermissions:
             ...
 
@@ -212,7 +214,9 @@ if TYPE_CHECKING:
         ) -> None:
             ...
 
-        async def delete_guild_announces(self, guild_id: int, message_id: str) -> None:
+        async def delete_guild_announces(
+            self, *, guild_id: int, message_id: str
+        ) -> None:
             ...
 
         async def post_channel_announces(
@@ -221,7 +225,7 @@ if TYPE_CHECKING:
             ...
 
         async def delete_channel_announces(
-            self, channel_id: int, message_id: str
+            self, *, channel_id: int, message_id: str
         ) -> None:
             ...
 
@@ -244,7 +248,7 @@ if TYPE_CHECKING:
         ) -> Schedule:
             ...
 
-        async def get_schedule(self, channel_id: int, schedule_id: int) -> Schedule:
+        async def get_schedule(self, *, channel_id: int, schedule_id: int) -> Schedule:
             ...
 
         async def patch_schedule(
@@ -262,7 +266,7 @@ if TYPE_CHECKING:
         ) -> Schedule:
             ...
 
-        async def delete_schedule(self, channel_id: int, schedule_id: int) -> None:
+        async def delete_schedule(self, *, channel_id: int, schedule_id: int) -> None:
             ...
 
         async def audio_control(
@@ -275,7 +279,9 @@ if TYPE_CHECKING:
         ) -> None:
             ...
 
-        async def get_guild_api_permission(self, guild_id: int) -> List[APIPermission]:
+        async def get_guild_api_permission(
+            self, *, guild_id: int
+        ) -> List[APIPermission]:
             ...
 
         async def post_api_permission_demand(
@@ -295,22 +301,24 @@ if TYPE_CHECKING:
             ...
 
         async def put_message_reaction(
-            self, channel_id: int, message_id: str, type: int, id: str
+            self, *, channel_id: int, message_id: str, type: int, id: str
         ) -> None:
             ...
 
         async def delete_own_message_reaction(
-            self, channel_id: int, message_id: str, type: int, id: str
+            self, *, channel_id: int, message_id: str, type: int, id: str
         ) -> None:
             ...
 
-        async def put_pins_message(self, channel_id: int, message_id: str) -> None:
+        async def put_pins_message(self, *, channel_id: int, message_id: str) -> None:
             ...
 
-        async def delete_pins_message(self, channel_id: int, message_id: str) -> None:
+        async def delete_pins_message(
+            self, *, channel_id: int, message_id: str
+        ) -> None:
             ...
 
-        async def get_pins_message(self, channel_id: int) -> PinsMessage:
+        async def get_pins_message(self, *, channel_id: int) -> PinsMessage:
             ...
 
 else:

--- a/nonebot/adapters/qqguild/api/client.py
+++ b/nonebot/adapters/qqguild/api/client.py
@@ -146,7 +146,7 @@ if TYPE_CHECKING:
         ) -> Message:
             ...
 
-        async def delete_message_of_id(
+        async def delete_message(
             self,
             *,
             channel_id: int,

--- a/nonebot/adapters/qqguild/api/client.py
+++ b/nonebot/adapters/qqguild/api/client.py
@@ -145,7 +145,7 @@ if TYPE_CHECKING:
 
         async def get_message_of_id(
             self, *, channel_id: int, message_id: str
-        ) -> Message:
+        ) -> MessageGet:
             ...
 
         async def delete_message(

--- a/nonebot/adapters/qqguild/api/handle.py
+++ b/nonebot/adapters/qqguild/api/handle.py
@@ -260,7 +260,8 @@ async def _get_message_of_id(
         adapter.get_api_base() / f"channels/{channel_id}/messages/{message_id}",
         headers={"Authorization": adapter.get_authorization(bot.bot_info)},
     )
-    return parse_obj_as(Message, await _request(adapter, bot, request))
+    resp = await _request(adapter, bot, request)
+    return parse_obj_as(Message, resp["message"])
 
 
 async def _delete_message(

--- a/nonebot/adapters/qqguild/api/handle.py
+++ b/nonebot/adapters/qqguild/api/handle.py
@@ -263,7 +263,7 @@ async def _get_message_of_id(
     return parse_obj_as(Message, await _request(adapter, bot, request))
 
 
-async def _delete_message_of_id(
+async def _delete_message(
     adapter: "Adapter",
     bot: "Bot",
     channel_id: int,
@@ -590,7 +590,7 @@ API_HANDLERS = {
     "get_channel_roles_permissions": _get_channel_roles_permissions,
     "put_channel_roles_permissions": _put_channel_roles_permissions,
     "get_message_of_id": _get_message_of_id,
-    "delete_message_of_id": _delete_message_of_id,
+    "delete_message": _delete_message,
     "post_messages": _post_messages,
     "post_dms": _post_dms,
     "post_dms_messages": _post_dms_messages,

--- a/nonebot/adapters/qqguild/api/handle.py
+++ b/nonebot/adapters/qqguild/api/handle.py
@@ -254,14 +254,13 @@ async def _put_channel_roles_permissions(
 
 async def _get_message_of_id(
     adapter: "Adapter", bot: "Bot", channel_id: int, message_id: str
-) -> Message:
+) -> MessageGet:
     request = Request(
         "GET",
         adapter.get_api_base() / f"channels/{channel_id}/messages/{message_id}",
         headers={"Authorization": adapter.get_authorization(bot.bot_info)},
     )
-    resp = await _request(adapter, bot, request)
-    return parse_obj_as(Message, resp["message"])
+    return parse_obj_as(MessageGet, await _request(adapter, bot, request))
 
 
 async def _delete_message(

--- a/nonebot/adapters/qqguild/api/model.py
+++ b/nonebot/adapters/qqguild/api/model.py
@@ -255,6 +255,10 @@ class Message(BaseModel):
     message_reference: Optional[MessageReference] = None
 
 
+class MessageGet(BaseModel):
+    message: Optional[Message] = None
+
+
 class MessageDelete(BaseModel):
     message: Optional[Message] = None
     op_user: Optional[User] = None

--- a/nonebot/adapters/qqguild/event.py
+++ b/nonebot/adapters/qqguild/event.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Type, Tuple
+from typing import Dict, Type, Tuple, Optional
 
 from nonebot.typing import overrides
 from nonebot.utils import escape_tag
@@ -9,7 +9,7 @@ from nonebot.adapters import Event as BaseEvent
 from .message import Message
 from .api import Message as GuildMessage
 from .api import User, Guild, Member, Channel
-from .api import MessageAudited, MessageReaction
+from .api import MessageGet, MessageAudited, MessageReaction
 
 
 class EventType(str, Enum):
@@ -185,6 +185,13 @@ class GuildMemberRemoveEvent(GuildMemberEvent):
 # Message Event
 class MessageEvent(Event, GuildMessage):
     to_me: bool = False
+
+    reply: Optional[MessageGet] = None
+    """
+    :说明: 消息中提取的回复消息，内容为 ``get_message_of_id`` API 返回结果
+
+    :类型: ``Optional[MessageGet]``
+    """
 
     @overrides(BaseEvent)
     def get_type(self) -> str:

--- a/nonebot/adapters/qqguild/message.py
+++ b/nonebot/adapters/qqguild/message.py
@@ -8,6 +8,7 @@ from nonebot.typing import overrides
 from nonebot.adapters import Message as BaseMessage
 from nonebot.adapters import MessageSegment as BaseMessageSegment
 
+from .event import MessageEvent
 from .utils import escape, unescape
 from .api import Message as GuildMessage
 from .api import MessageArk, MessageEmbed, MessageReference
@@ -177,7 +178,10 @@ class Message(BaseMessage[MessageSegment]):
     @classmethod
     def from_guild_message(cls, message: GuildMessage) -> "Message":
         msg = Message()
-        if message.message_reference:
+        to_me = False
+        if isinstance(message, MessageEvent) and message.to_me:
+            to_me = True
+        if message.message_reference and not to_me:
             msg.append(
                 Reference("reference", data={"reference": message.message_reference})
             )

--- a/nonebot/adapters/qqguild/message.py
+++ b/nonebot/adapters/qqguild/message.py
@@ -8,7 +8,6 @@ from nonebot.typing import overrides
 from nonebot.adapters import Message as BaseMessage
 from nonebot.adapters import MessageSegment as BaseMessageSegment
 
-from .event import MessageEvent
 from .utils import escape, unescape
 from .api import Message as GuildMessage
 from .api import MessageArk, MessageEmbed, MessageReference
@@ -178,13 +177,6 @@ class Message(BaseMessage[MessageSegment]):
     @classmethod
     def from_guild_message(cls, message: GuildMessage) -> "Message":
         msg = Message()
-        to_me = False
-        if isinstance(message, MessageEvent) and message.to_me:
-            to_me = True
-        if message.message_reference and not to_me:
-            msg.append(
-                Reference("reference", data={"reference": message.message_reference})
-            )
         if message.mention_everyone:
             msg.append(MessageSegment.mention_everyone())
         if message.content:

--- a/nonebot/adapters/qqguild/message.py
+++ b/nonebot/adapters/qqguild/message.py
@@ -177,6 +177,12 @@ class Message(BaseMessage[MessageSegment]):
     @classmethod
     def from_guild_message(cls, message: GuildMessage) -> "Message":
         msg = Message()
+        if message.message_reference:
+            msg.append(
+                Reference("reference", data={"reference": message.message_reference})
+            )
+        if message.mention_everyone:
+            msg.append(MessageSegment.mention_everyone())
         if message.content:
             msg.extend(Message(message.content))
         if message.attachments:
@@ -189,12 +195,6 @@ class Message(BaseMessage[MessageSegment]):
             msg.extend(Embed("embed", data={"embed": seg}) for seg in message.embeds)
         if message.ark:
             msg.append(Ark("ark", data={"ark": message.ark}))
-        if message.message_reference:
-            msg.append(
-                Reference("reference", data={"reference": message.message_reference})
-            )
-        if message.mention_everyone:
-            msg.append(MessageSegment.mention_everyone())
         return msg
 
     def extract_content(self) -> str:


### PR DESCRIPTION
没注意到 delete_message 才是官方的名称。

<https://bot.q.qq.com/wiki/develop/api/openapi/message/delete_message.html>