### PR TITLE
Feature: 为 reference 提供一种更易用的使用方式

### DIFF
--- a/nonebot/adapters/qqguild/message.py
+++ b/nonebot/adapters/qqguild/message.py
@@ -57,9 +57,7 @@ class MessageSegment(BaseMessageSegment["Message"]):
 
     @overload
     @staticmethod
-    def reference(
-        reference: MessageReference, ignore_error: None = None
-    ) -> "Reference":
+    def reference(reference: MessageReference) -> "Reference":
         ...
 
     @overload

--- a/nonebot/adapters/qqguild/message.py
+++ b/nonebot/adapters/qqguild/message.py
@@ -1,7 +1,7 @@
 import re
 from io import BytesIO
 from pathlib import Path
-from typing import Type, Union, Iterable
+from typing import Type, Union, Iterable, Optional, overload
 
 from nonebot.typing import overrides
 
@@ -55,8 +55,32 @@ class MessageSegment(BaseMessageSegment["Message"]):
     def mention_everyone() -> "MentionEveryone":
         return MentionEveryone("mention_everyone", {})
 
+    @overload
     @staticmethod
     def reference(reference: MessageReference) -> "Reference":
+        ...
+
+    @overload
+    @staticmethod
+    def reference(
+        message_id: str, ignore_get_message_error: Optional[bool] = None
+    ) -> "Reference":
+        ...
+
+    @staticmethod
+    def reference(*args, **kwargs) -> "Reference":
+        if (
+            len(args) > 0 and isinstance(reference := args[0], MessageReference)
+        ) or isinstance(reference := kwargs.get("reference"), MessageReference):
+            return Reference("reference", data={"reference": reference})
+
+        msg_id = (args[0] if len(args) > 0 else None) or (kwargs.get("message_id"))
+        ignore_get_message_error = (args[1] if len(args) > 1 else None) or (
+            kwargs.get("ignore_get_message_error")
+        )
+        reference = MessageReference(
+            message_id=msg_id, ignore_get_message_error=ignore_get_message_error
+        )
         return Reference("reference", data={"reference": reference})
 
     @staticmethod

--- a/nonebot/adapters/qqguild/message.py
+++ b/nonebot/adapters/qqguild/message.py
@@ -57,31 +57,31 @@ class MessageSegment(BaseMessageSegment["Message"]):
 
     @overload
     @staticmethod
-    def reference(reference: MessageReference) -> "Reference":
+    def reference(
+        reference: MessageReference, ignore_error: None = None
+    ) -> "Reference":
         ...
 
     @overload
     @staticmethod
-    def reference(
-        message_id: str, ignore_get_message_error: Optional[bool] = None
-    ) -> "Reference":
+    def reference(reference: str, ignore_error: Optional[bool] = None) -> "Reference":
         ...
 
     @staticmethod
-    def reference(*args, **kwargs) -> "Reference":
-        if (
-            len(args) > 0 and isinstance(reference := args[0], MessageReference)
-        ) or isinstance(reference := kwargs.get("reference"), MessageReference):
+    def reference(
+        reference: Union[str, MessageReference], ignore_error: Optional[bool] = None
+    ) -> "Reference":
+        if isinstance(reference, MessageReference):
             return Reference("reference", data={"reference": reference})
 
-        msg_id = (args[0] if len(args) > 0 else None) or (kwargs.get("message_id"))
-        ignore_get_message_error = (args[1] if len(args) > 1 else None) or (
-            kwargs.get("ignore_get_message_error")
+        return Reference(
+            "reference",
+            data={
+                "reference": MessageReference(
+                    message_id=reference, ignore_get_message_error=ignore_error
+                )
+            },
         )
-        reference = MessageReference(
-            message_id=msg_id, ignore_get_message_error=ignore_get_message_error
-        )
-        return Reference("reference", data={"reference": reference})
 
     @staticmethod
     def text(content: str) -> "Text":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ model-output = "nonebot/adapters/qqguild/api/model.py"
 client-output = "nonebot/adapters/qqguild/api/client.py"
 handle-output = "nonebot/adapters/qqguild/api/handle.py"
 
+[tool.pyright]
+pythonVersion = "3.8"
+pythonPlatform = "All"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,15 +48,15 @@ skip_gitignore = true
 force_sort_within_sections = true
 extra_standard_library = ["typing_extensions"]
 
+[tool.pyright]
+pythonVersion = "3.8"
+pythonPlatform = "All"
+
 [tool.codegen]
 url = "https://cdn.jsdelivr.net/gh/tencent-connect/bot-oas/v1/openapi.yaml"
 model-output = "nonebot/adapters/qqguild/api/model.py"
 client-output = "nonebot/adapters/qqguild/api/client.py"
 handle-output = "nonebot/adapters/qqguild/api/handle.py"
-
-[tool.pyright]
-pythonVersion = "3.8"
-pythonPlatform = "All"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
* 在 pyproject.toml 中加入 pyright 的设置
* 为 MessageSegment.reference 加入新的更易用的使用方式

NOTE：在这个新增加的使用方式中使用了新的签名，但是 impl 的代码变得丑陋并且不易读。当然如果把 `reference` 和 `message_id` 两个变量名统一后这里的实现会简单很多，但是 `reference: MessageReference` 和 `message_id: str` 所代表的含义不同，所以认为参数名上还是做一个区分的好。所以这里也请教一下 `reference` impl 的写法有没有更加好的形式