### PR TITLE
Fix: 接收到 ReadyEvent 后还需要设置 bot.sequence

### DIFF
--- a/nonebot/adapters/qqguild/adapter.py
+++ b/nonebot/adapters/qqguild/adapter.py
@@ -251,6 +251,7 @@ class Adapter(BaseAdapter):
             assert isinstance(
                 payload, Dispatch
             ), f"Received unexpected payload: {payload!r}"
+            bot.sequence = payload.sequence
             ready_event = self.payload_to_event(payload)
             assert isinstance(
                 ready_event, ReadyEvent


### PR DESCRIPTION
发送 Resume 事件时需要这个参数。