### PR TITLE
修复在使用file_image时，请求中的msg_id和content等字段丢失

### DIFF
--- a/nonebot/adapters/qqguild/api/utils.py
+++ b/nonebot/adapters/qqguild/api/utils.py
@@ -20,6 +20,7 @@ def parse_send_message(data: Dict[str, Any]) -> Dict[str, Any]:
                 )
             else:
                 data_[k] = (None, v.encode("utf-8"), "text/plain")
+        data_.update(model_data)
         params = {"files": data_}
     else:
         params = {"json": model_data}


### PR DESCRIPTION
修复在使用file_image时，请求中的msg_id和content等字段丢失。这个问题会导致文本消息未发送或消息被识别为主动消息的情况